### PR TITLE
Requestfix

### DIFF
--- a/AFAmazonS3Client.m
+++ b/AFAmazonS3Client.m
@@ -236,7 +236,7 @@ NSString * const kAFAmazonS3BucketBaseURLFormatString = @"http://%@.s3.amazonaws
     NSData *data = [NSURLConnection sendSynchronousRequest:fileRequest returningResponse:&response error:&error];
 
     if (data && response) {
-        NSMutableURLRequest *request = [self multipartFormRequestWithMethod:path path:@"/" parameters:parameters constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
+        NSMutableURLRequest *request = [self multipartFormRequestWithMethod:method path:path parameters:parameters constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
             [formData appendPartWithFileData:data name:@"file" fileName:[path lastPathComponent] mimeType:[response MIMEType]];
         }];
 


### PR DESCRIPTION
This Pull Request fixes two issues.
1. The -(NSURL)baseURL method can return a NSString object instead of a NSURL object.
   I've also changed the logic to always use the bucket name when both it and the baseURL are available.
2. The setObjectWithMethod:... method was passing the incorrect parameters to the multipartFormRequestWithMethod: which was causing 405's from S3, and failed uploads.
