### PR TITLE
Add AWS 'key' form input element according to AWS documentation

### DIFF
--- a/AFAmazonS3Client.podspec
+++ b/AFAmazonS3Client.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'AFNetworking', '~> 1.0'
-  s.dependency 'ISO8601Formatter', '~> 0.6'
+  s.dependency 'ISO8601DateFormatter', '~> 0.6'
 end

--- a/AFAmazonS3Client/AFAmazonS3Client.m
+++ b/AFAmazonS3Client/AFAmazonS3Client.m
@@ -353,7 +353,7 @@ static NSData * AFHMACSHA1FromStringWithKey(NSString *string, NSString *key){
     
     NSDate *expirationDate = [NSDate dateWithTimeIntervalSinceNow:NSIntegerMax];
     
-    NSString *expirationDateString = [[self dateFormatter] stringFromDate:expirationDate timeZone:[NSTimeZone defaultTimeZone]];
+    NSString *expirationDateString = [[self dateFormatter] stringFromDate:expirationDate timeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
     
     NSMutableDictionary *policy = [NSMutableDictionary dictionaryWithObject:expirationDateString forKey:@"expiration"];
     


### PR DESCRIPTION
http://doc.s3.amazonaws.com/proposals/post.html#Access_Control_Example

The above document explains that 'key' is a mandatory form element when
submitting POST requests to S3. I have added this element before 'file' since
the order matters:

https://forums.aws.amazon.com/message.jspa?messageID=131965
