### PR TITLE
Add a missing parameter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ As the S3 API returns XML responses, you may find it useful to include [AFKissXM
 ```objective-c
 AFAmazonS3Client *s3Client = [[AFAmazonS3Client alloc] initWithAccessKeyID:@"..." secret:@"..."];
     s3Client.bucket = @"my-bucket-name";
-    [s3Client postObjectWithFile:@"/path/to/file" parameters:nil progress:^(NSInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite) {
+    [s3Client postObjectWithFile:@"/path/to/file" destinationPath:@"https://s3.amazonaws.com/example" parameters:nil progress:^(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite) {
         NSLog(@"%f%% Uploaded", (totalBytesWritten / (totalBytesExpectedToWrite * 1.0f) * 100));
     } success:^(id responseObject) {
         NSLog(@"Upload Complete");


### PR DESCRIPTION
- `-postObjectWithFile` requires `destinationPath` now
- The first arg of its arg `progress` was wrong (NSInteger -> NSUInteger)
