### PR TITLE
Add prefix header imports

### DIFF
--- a/AFAmazonS3Client.podspec
+++ b/AFAmazonS3Client.podspec
@@ -12,4 +12,21 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'AFNetworking', '~> 1.3'
+  
+  s.prefix_header_contents = <<-EOS
+#import <Availability.h>
+
+#define _AFNETWORKING_PIN_SSL_CERTIFICATES_
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <MobileCoreServices/MobileCoreServices.h>
+  #import <Security/Security.h>
+#else
+  #import <SystemConfiguration/SystemConfiguration.h>
+  #import <CoreServices/CoreServices.h>
+  #import <Security/Security.h>
+#endif
+EOS
+
 end


### PR DESCRIPTION
This gets rid of warnings pertaining to missing imports when using CocoaPods.
