### PR TITLE
Temporary session token support

### DIFF
--- a/AFAmazonS3Client/AFAmazonS3Manager.m
+++ b/AFAmazonS3Client/AFAmazonS3Manager.m
@@ -260,7 +260,7 @@ NSString * const AFAmazonS3ManagerErrorDomain = @"com.alamofire.networking.s3.er
 #pragma mark - NSKeyValueObserving
 
 + (NSSet *)keyPathsForValuesAffectingBaseURL {
-    return [NSSet setWithObjects:@"baseURL", @"requestSerializer.bucket", @"requestSerializer.region", @"requestSerializer.useSSL", nil];
+    return [NSSet setWithObjects:@"baseURL", @"requestSerializer.bucket", @"requestSerializer.region", @"requestSerializer.sessionToken", @"requestSerializer.useSSL", nil];
 }
 
 @end

--- a/AFAmazonS3Client/AFAmazonS3RequestSerializer.h
+++ b/AFAmazonS3Client/AFAmazonS3RequestSerializer.h
@@ -42,6 +42,11 @@
 @property (nonatomic, copy) NSString *region;
 
 /**
+ The AWS STS session token. `nil` by default.
+ */
+@property (nonatomic, copy) NSString *sessionToken;
+
+/**
  Whether to connect over HTTPS. `YES` by default.
 
  @see `AFAmazonS3Client -baseURL`

--- a/AFAmazonS3Client/AFAmazonS3RequestSerializer.m
+++ b/AFAmazonS3Client/AFAmazonS3RequestSerializer.m
@@ -194,7 +194,13 @@ static NSString * AFBase64EncodedStringFromData(NSData *data) {
                                 parameters:(NSDictionary *)parameters
                                      error:(NSError *__autoreleasing *)error
 {
-    return [[self requestBySettingAuthorizationHeadersForRequest:[super requestWithMethod:method URLString:URLString parameters:parameters error:error] error:error] mutableCopy];
+    NSMutableURLRequest *request = [super requestWithMethod:method URLString:URLString parameters:parameters error:error];
+
+    if (self.sessionToken) {
+        [request setValue:self.sessionToken forHTTPHeaderField:@"x-amz-security-token"];
+    }
+
+    return [[self requestBySettingAuthorizationHeadersForRequest:request error:error] mutableCopy];
 }
 
 - (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
@@ -203,7 +209,13 @@ static NSString * AFBase64EncodedStringFromData(NSData *data) {
                               constructingBodyWithBlock:(void (^)(id<AFMultipartFormData>))block
                                                   error:(NSError *__autoreleasing *)error
 {
-    return [[self requestBySettingAuthorizationHeadersForRequest:[super multipartFormRequestWithMethod:method URLString:URLString parameters:parameters constructingBodyWithBlock:block error:error] error:error] mutableCopy];
+    NSMutableURLRequest *request = [super multipartFormRequestWithMethod:method URLString:URLString parameters:parameters constructingBodyWithBlock:block error:error];
+
+    if (self.sessionToken) {
+        [request setValue:self.sessionToken forHTTPHeaderField:@"x-amz-security-token"];
+    }
+
+    return [[self requestBySettingAuthorizationHeadersForRequest:request error:error] mutableCopy];
 }
 
 @end


### PR DESCRIPTION
This adds support for passing in temporary AWS STS credentials, which include a session token.
