### PR TITLE
bucket name can be passed on url path.  if bucket is not set then just u...

### DIFF
--- a/AFAmazonS3Client/AFAmazonS3RequestSerializer.m
+++ b/AFAmazonS3Client/AFAmazonS3RequestSerializer.m
@@ -158,7 +158,7 @@ static NSString * AFBase64EncodedStringFromData(NSData *data) {
 			[mutableCanonicalizedAMZHeaderString appendFormat:@"%@:%@\n", key, value];
 		}
 
-        NSString *canonicalizedResource = [NSString stringWithFormat:@"/%@%@", self.bucket, request.URL.path];
+        NSString *canonicalizedResource = self.bucket ? [NSString stringWithFormat:@"/%@%@", self.bucket, request.URL.path] :  request.URL.path;
     	NSString *method = [request HTTPMethod];
 		NSString *contentMD5 = [request valueForHTTPHeaderField:@"Content-MD5"];
 		NSString *contentType = [request valueForHTTPHeaderField:@"Content-Type"];


### PR DESCRIPTION
...se the request url path.  otherwise canonical resource header is not set correctly causing AWS to return a 403 forbidden
