### PR TITLE
Fixed initWithAccessKeyID:accessKey secret:secret

### DIFF
--- a/AFAmazonS3Client/AFAmazonS3Manager.m
+++ b/AFAmazonS3Client/AFAmazonS3Manager.m
@@ -46,7 +46,7 @@ NSString * const AFAmazonS3ManagerErrorDomain = @"com.alamofire.networking.s3.er
 - (id)initWithAccessKeyID:(NSString *)accessKey
                    secret:(NSString *)secret
 {
-    self = [self init];
+    self = [self initWithBaseURL:nil];
     if (!self) {
         return nil;
     }


### PR DESCRIPTION
Before this change, using this init method would never create a request or response serializer so nothing would work, and it would fail silently.
