### PR TITLE
Updated README to reflect proper configuration of region and bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ As the S3 API returns XML responses, you may find it useful to set [AFOnoRespons
 
 ```objective-c
 AFAmazonS3Manager *s3Manager = [[AFAmazonS3Manager alloc] initWithAccessKeyID:@"..." secret:@"..."];
-s3Manager.region = AFAmazonS3USWest1Region;
-s3Manager.bucket = @"my-bucket-name";
+s3Manager.requestSerializer.region = AFAmazonS3USWest1Region;
+s3Manager.requestSerializer.bucket = @"my-bucket-name";
 
 [s3Manager postObjectWithFile:@"/path/to/file"
               destinationPath:@"https://s3.amazonaws.com/example"


### PR DESCRIPTION
The code sample for configuring region and bucket in the README did not compile. This seems to be the right way to do it now.
