### PR TITLE
Added method to generate a pre-signed query URL

### DIFF
--- a/AFAmazonS3Client/AFAmazonS3RequestSerializer.h
+++ b/AFAmazonS3Client/AFAmazonS3RequestSerializer.h
@@ -65,6 +65,17 @@
                 secret:(NSString *)secret;
 
 /**
+ Returns a URL for an object at the given path.
+
+ @param path The path to the object in the bucket.
+
+ @return An `NSURL` of a pre-signed query request URL to access the object through the REST API via URL.
+*/
+- (NSURL *)preSignedQueryURLWithPath:(NSString *)path;
+
+
+
+/**
  Returns the AWS authorization HTTP header fields for the specified request.
 
  @param request The request.


### PR DESCRIPTION
This method allows you to get a URL using a pre-signed query request to access the REST API. 

As per: http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
