### PR TITLE
change cache policy to match enumeration  type

### DIFF
--- a/AFAmazonS3Client/AFAmazonS3Manager.m
+++ b/AFAmazonS3Client/AFAmazonS3Manager.m
@@ -220,7 +220,7 @@ NSString * const AFAmazonS3ManagerErrorDomain = @"com.alamofire.networking.s3.er
                     failure:(void (^)(NSError *error))failure
 {
     NSMutableURLRequest *fileRequest = [NSMutableURLRequest requestWithURL:[NSURL fileURLWithPath:filePath]];
-    [fileRequest setCachePolicy:NSURLCacheStorageNotAllowed];
+    [fileRequest setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
 	
     NSURLResponse *response = nil;
     NSError *fileError = nil;


### PR DESCRIPTION
Warning Given : AFAmazonS3Client/AFAmazonS3Manager.m:223:33: Implicit conversion from enumeration type 'enum NSURLCacheStoragePolicy' to different enumeration type 'NSURLRequestCachePolicy' (aka 'enum NSURLRequestCachePolicy')
