### PR TITLE
Replacing spaces in destinationPath with pluses

### DIFF
--- a/AFAmazonS3Client/AFAmazonS3Manager.m
+++ b/AFAmazonS3Client/AFAmazonS3Manager.m
@@ -227,6 +227,8 @@ NSString * const AFAmazonS3ManagerErrorDomain = @"com.alamofire.networking.s3.er
     NSData *data = [NSURLConnection sendSynchronousRequest:fileRequest returningResponse:&response error:&fileError];
 	
     if (data && response) {
+        destinationPath = [destinationPath stringByReplacingOccurrencesOfString:@" " withString:@"+"];
+
         NSMutableURLRequest *request = [self.requestSerializer multipartFormRequestWithMethod:method URLString:[[self.baseURL URLByAppendingPathComponent:destinationPath] absoluteString] parameters:parameters constructingBodyWithBlock:^(id <AFMultipartFormData> formData) {
             if (![parameters valueForKey:@"key"]) {
                 [formData appendPartWithFormData:[[filePath lastPathComponent] dataUsingEncoding:NSUTF8StringEncoding] name:@"key"];


### PR DESCRIPTION
Replacing spaces in destinationPath with pluses, since that's what S3 expects, and uploads fail without that. The files still end up with spaces in the S3 console (fixes Issue #61).
