### PR TITLE
Amazon expects the signature to have an escaped path

### DIFF
--- a/AFAmazonS3Manager/AFAmazonS3RequestSerializer.m
+++ b/AFAmazonS3Manager/AFAmazonS3RequestSerializer.m
@@ -106,8 +106,10 @@ static NSString * AFAWSSignatureForRequest(NSURLRequest *request, NSString *buck
         id value = [mutableAMZHeaderFields objectForKey:field];
         [mutableCanonicalizedAMZHeaderString appendFormat:@"%@:%@\n", field, value];
     }
-
-    NSString *canonicalizedResource = bucket ? [NSString stringWithFormat:@"/%@%@", bucket, request.URL.path] : request.URL.path;
+    
+    NSString *urlEscapedPath = [[request.URL.path stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] stringByReplacingOccurrencesOfString:@"&" withString:@"%26"];
+    
+    NSString *canonicalizedResource = bucket ? [NSString stringWithFormat:@"/%@%@", bucket, urlEscapedPath] : urlEscapedPath;
     NSString *method = [request HTTPMethod];
     NSString *contentMD5 = [request valueForHTTPHeaderField:@"Content-MD5"];
     NSString *contentType = [request valueForHTTPHeaderField:@"Content-Type"];


### PR DESCRIPTION
I found an issue, where Amazon allows for spaces in the paths on S3 but the manager was not supporting it.  Turns out that URL.path returns an unescaped string.

This causes a signature mismatch error (403) to be returned.

The restrictions on bucket names, make it so we don't have to escape them as well.

I know there are several posts about how stringByAddingPercentEscapesUsingEncoding: is a poor method to use for escaping URLs, because it doesn't escape / and & correctly, however there are a few reasons I used it here:
1) we are dealing with a path, so there are characters that we don't want to escape, like /
2) there shouldn't be any query parameters in the URLs so we need to escape & because they are in the name of the folder or file name.