### PR TITLE
Added a return type of AFHTTPRequestOperation for AmazonS3Manager methods

### DIFF
--- a/AFAmazonS3Manager/AFAmazonS3Manager.h
+++ b/AFAmazonS3Manager/AFAmazonS3Manager.h
@@ -58,12 +58,14 @@
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ 
+ @return The operation that was enqueued on operationQueue
  */
-- (void)enqueueS3RequestOperationWithMethod:(NSString *)method
-                                       path:(NSString *)path
-                                 parameters:(NSDictionary *)parameters
-                                    success:(void (^)(id responseObject))success
-                                    failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)enqueueS3RequestOperationWithMethod:(NSString *)method
+                                                           path:(NSString *)path
+                                                     parameters:(NSDictionary *)parameters
+                                                        success:(void (^)(id responseObject))success
+                                                        failure:(void (^)(NSError *error))failure;
 
 ///-------------------------
 /// @name Service Operations
@@ -74,9 +76,11 @@
 
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ 
+ @return The operation that was enqueued on operationQueue
  */
-- (void)getServiceWithSuccess:(void (^)(id responseObject))success
-                      failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)getServiceWithSuccess:(void (^)(id responseObject))success
+                                          failure:(void (^)(NSError *error))failure;
 
 
 ///------------------------
@@ -89,10 +93,12 @@
  @param bucket The S3 bucket to get. Must not be `nil`.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ 
+ @return The operation that was enqueued on operationQueue
  */
-- (void)getBucket:(NSString *)bucket
-          success:(void (^)(id responseObject))success
-          failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)getBucket:(NSString *)bucket
+                              success:(void (^)(id responseObject))success
+                              failure:(void (^)(NSError *error))failure;
 
 /**
  Creates a new bucket belonging to the account of the authenticated request sender. Optionally, you can specify a EU (Ireland) or US-West (N. California) location constraint.
@@ -101,11 +107,13 @@
  @param parameters The parameters to be encoded and set in the request HTTP body.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ 
+ @return The operation that was enqueued on operationQueue
  */
-- (void)putBucket:(NSString *)bucket
-       parameters:(NSDictionary *)parameters
-          success:(void (^)(id responseObject))success
-          failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)putBucket:(NSString *)bucket
+                           parameters:(NSDictionary *)parameters
+                              success:(void (^)(id responseObject))success
+                              failure:(void (^)(NSError *error))failure;
 
 /**
  Deletes the specified bucket. All objects in the bucket must be deleted before the bucket itself can be deleted.
@@ -113,10 +121,12 @@
  @param bucket The S3 bucket to be delete. Must not be `nil`.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ 
+ @return The operation that was enqueued on operationQueue
  */
-- (void)deleteBucket:(NSString *)bucket
-             success:(void (^)(id responseObject))success
-             failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)deleteBucket:(NSString *)bucket
+                                 success:(void (^)(id responseObject))success
+                                 failure:(void (^)(NSError *error))failure;
 
 ///----------------------------------------------
 /// @name Object Operations
@@ -140,11 +150,13 @@
  @param progress A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes read since the last time the download progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times, and will execute on the main thread.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ 
+ @return The operation that was enqueued
  */
-- (void)getObjectWithPath:(NSString *)path
-                 progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
-                  success:(void (^)(id responseObject, NSData *responseData))success
-                  failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)getObjectWithPath:(NSString *)path
+                                     progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
+                                      success:(void (^)(id responseObject, NSData *responseData))success
+                                      failure:(void (^)(NSError *error))failure;
 
 /**
  Gets an object for a user that has read access to the object.
@@ -154,12 +166,14 @@
  @param progress A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes read since the last time the download progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times, and will execute on the main thread.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ 
+ @return The operation that was enqueued
  */
-- (void)getObjectWithPath:(NSString *)path
-             outputStream:(NSOutputStream *)outputStream
-                 progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
-                  success:(void (^)(id responseObject))success
-                  failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)getObjectWithPath:(NSString *)path
+                                 outputStream:(NSOutputStream *)outputStream
+                                     progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
+                                      success:(void (^)(id responseObject))success
+                                      failure:(void (^)(NSError *error))failure;
 
 /**
  Adds an object to a bucket using forms.
@@ -173,12 +187,12 @@
 
  @discussion `destinationPath` is relative to the bucket's root, and will create any intermediary directories as necessary. For example, specifying "/a/b/c.txt" will create the "/a" and / or "/a/b" directories within the bucket, if they do not already exist, and upload the source file as "c.txt" into "/a/b".
  */
-- (void)postObjectWithFile:(NSString *)path
-           destinationPath:(NSString *)destinationPath
-                parameters:(NSDictionary *)parameters
-                  progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
-                   success:(void (^)(id responseObject))success
-                   failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)postObjectWithFile:(NSString *)path
+                               destinationPath:(NSString *)destinationPath
+                                    parameters:(NSDictionary *)parameters
+                                      progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                                       success:(void (^)(id responseObject))success
+                                       failure:(void (^)(NSError *error))failure;
 
 /**
  Adds an object to a bucket for a user that has write access to the bucket. A success response indicates the object was successfully stored; if the object already exists, it will be overwritten.
@@ -189,15 +203,17 @@
  @param progress A block object to be called when an undetermined number of bytes have been uploaded to the server. This block has no return value and takes three arguments: the number of bytes written since the last time the upload progress block was called, the total bytes written, and the total bytes expected to be written during the request, as initially determined by the length of the HTTP body. This block may be called multiple times, and will execute on the main thread.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ 
+ @return The operation that was enqueued on operationQueue
 
  @discussion `destinationPath` is relative to the bucket's root, and will create any intermediary directories as necessary. For example, specifying "/a/b/c.txt" will create the "/a" and / or "/a/b" directories within the bucket, if they do not already exist, and upload the source file as "c.txt" into "/a/b".
  */
-- (void)putObjectWithFile:(NSString *)path
-          destinationPath:(NSString *)destinationPath
-               parameters:(NSDictionary *)parameters
-                 progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
-                  success:(void (^)(id responseObject))success
-                  failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)putObjectWithFile:(NSString *)path
+                              destinationPath:(NSString *)destinationPath
+                                   parameters:(NSDictionary *)parameters
+                                     progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                                      success:(void (^)(id responseObject))success
+                                      failure:(void (^)(NSError *error))failure;
 
 /**
  Deletes the specified object. Once deleted, there is no method to restore or undelete an object.
@@ -205,10 +221,12 @@
  @param path The path for the remote file to be deleted. Must not be `nil`.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the response object from the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the `NSError` object describing error that occurred.
+ 
+ @return The operation that was enqueued on operationQueue
  */
-- (void)deleteObjectWithPath:(NSString *)path
-                     success:(void (^)(id responseObject))success
-                     failure:(void (^)(NSError *error))failure;
+- (AFHTTPRequestOperation *)deleteObjectWithPath:(NSString *)path
+                                         success:(void (^)(id responseObject))success
+                                         failure:(void (^)(NSError *error))failure;
 
 @end
 

--- a/AFAmazonS3Manager/AFAmazonS3Manager.m
+++ b/AFAmazonS3Manager/AFAmazonS3Manager.m
@@ -71,11 +71,11 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
 
 #pragma mark -
 
-- (void)enqueueS3RequestOperationWithMethod:(NSString *)method
-                                       path:(NSString *)path
-                                 parameters:(NSDictionary *)parameters
-                                    success:(void (^)(id responseObject))success
-                                    failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)enqueueS3RequestOperationWithMethod:(NSString *)method
+                                                           path:(NSString *)path
+                                                     parameters:(NSDictionary *)parameters
+                                                        success:(void (^)(id responseObject))success
+                                                        failure:(void (^)(NSError *error))failure
 {
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:method URLString:[[self.baseURL URLByAppendingPathComponent:path] absoluteString] parameters:parameters error:nil];
     AFHTTPRequestOperation *requestOperation = [self HTTPRequestOperationWithRequest:request success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {
@@ -89,53 +89,54 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
     }];
 
     [self.operationQueue addOperation:requestOperation];
+    
+    return requestOperation;
 }
 
 
 #pragma mark Service Operations
 
-- (void)getServiceWithSuccess:(void (^)(id responseObject))success
-                      failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)getServiceWithSuccess:(void (^)(id responseObject))success
+                                          failure:(void (^)(NSError *error))failure
 {
-    [self enqueueS3RequestOperationWithMethod:@"GET" path:@"/" parameters:nil success:success failure:failure];
+    return [self enqueueS3RequestOperationWithMethod:@"GET" path:@"/" parameters:nil success:success failure:failure];
 }
 
 #pragma mark Bucket Operations
 
-- (void)getBucket:(NSString *)bucket
-          success:(void (^)(id responseObject))success
-          failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)getBucket:(NSString *)bucket
+                              success:(void (^)(id responseObject))success
+                              failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(bucket);
 
-    [self enqueueS3RequestOperationWithMethod:@"GET" path:bucket parameters:nil success:success failure:failure];
+    return [self enqueueS3RequestOperationWithMethod:@"GET" path:bucket parameters:nil success:success failure:failure];
 }
 
-- (void)putBucket:(NSString *)bucket
-       parameters:(NSDictionary *)parameters
-          success:(void (^)(id responseObject))success
-          failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)putBucket:(NSString *)bucket
+                           parameters:(NSDictionary *)parameters
+                              success:(void (^)(id responseObject))success
+                              failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(bucket);
-
-    [self enqueueS3RequestOperationWithMethod:@"PUT" path:bucket parameters:parameters success:success failure:failure];
-
+    
+    return [self enqueueS3RequestOperationWithMethod:@"PUT" path:bucket parameters:parameters success:success failure:failure];
 }
 
-- (void)deleteBucket:(NSString *)bucket
-             success:(void (^)(id responseObject))success
-             failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)deleteBucket:(NSString *)bucket
+                                 success:(void (^)(id responseObject))success
+                                 failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(bucket);
-
-    [self enqueueS3RequestOperationWithMethod:@"DELETE" path:bucket parameters:nil success:success failure:failure];
+    
+    return [self enqueueS3RequestOperationWithMethod:@"DELETE" path:bucket parameters:nil success:success failure:failure];
 }
 
 #pragma mark Object Operations
 
-- (void)headObjectWithPath:(NSString *)path
-                   success:(void (^)(NSHTTPURLResponse *response))success
-                   failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)headObjectWithPath:(NSString *)path
+                                       success:(void (^)(NSHTTPURLResponse *response))success
+                                       failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(path);
 
@@ -153,12 +154,14 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
     }];
 
     [self.operationQueue addOperation:requestOperation];
+    
+    return requestOperation;
 }
 
-- (void)getObjectWithPath:(NSString *)path
-                 progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
-                  success:(void (^)(id responseObject, NSData *responseData))success
-                  failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)getObjectWithPath:(NSString *)path
+                                     progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
+                                      success:(void (^)(id responseObject, NSData *responseData))success
+                                      failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(path);
 
@@ -178,13 +181,15 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
     [requestOperation setDownloadProgressBlock:progress];
 
     [self.operationQueue addOperation:requestOperation];
+    
+    return requestOperation;
 }
 
-- (void)getObjectWithPath:(NSString *)path
-             outputStream:(NSOutputStream *)outputStream
-                 progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
-                  success:(void (^)(id responseObject))success
-                  failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)getObjectWithPath:(NSString *)path
+                                 outputStream:(NSOutputStream *)outputStream
+                                     progress:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))progress
+                                      success:(void (^)(id responseObject))success
+                                      failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(path);
 
@@ -206,35 +211,37 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
     [requestOperation setDownloadProgressBlock:progress];
 
     [self.operationQueue addOperation:requestOperation];
+    
+    return requestOperation;
 }
 
-- (void)postObjectWithFile:(NSString *)path
-           destinationPath:(NSString *)destinationPath
-                parameters:(NSDictionary *)parameters
-                  progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
-                   success:(void (^)(id responseObject))success
-                   failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)postObjectWithFile:(NSString *)path
+                               destinationPath:(NSString *)destinationPath
+                                    parameters:(NSDictionary *)parameters
+                                      progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                                       success:(void (^)(id responseObject))success
+                                       failure:(void (^)(NSError *error))failure
 {
-    [self setObjectWithMethod:@"POST" file:path destinationPath:destinationPath parameters:parameters progress:progress success:success failure:failure];
+    return [self setObjectWithMethod:@"POST" file:path destinationPath:destinationPath parameters:parameters progress:progress success:success failure:failure];
 }
 
-- (void)putObjectWithFile:(NSString *)path
-          destinationPath:(NSString *)destinationPath
-               parameters:(NSDictionary *)parameters
-                 progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
-                  success:(void (^)(id responseObject))success
-                  failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)putObjectWithFile:(NSString *)path
+                              destinationPath:(NSString *)destinationPath
+                                   parameters:(NSDictionary *)parameters
+                                     progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                                      success:(void (^)(id responseObject))success
+                                      failure:(void (^)(NSError *error))failure
 {
-    [self setObjectWithMethod:@"PUT" file:path destinationPath:destinationPath parameters:parameters progress:progress success:success failure:failure];
+    return [self setObjectWithMethod:@"PUT" file:path destinationPath:destinationPath parameters:parameters progress:progress success:success failure:failure];
 }
 
-- (void)setObjectWithMethod:(NSString *)method
-                       file:(NSString *)filePath
-            destinationPath:(NSString *)destinationPath
-                 parameters:(NSDictionary *)parameters
-                   progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
-                    success:(void (^)(id responseObject))success
-                    failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)setObjectWithMethod:(NSString *)method
+                                           file:(NSString *)filePath
+                                destinationPath:(NSString *)destinationPath
+                                     parameters:(NSDictionary *)parameters
+                                       progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress
+                                        success:(void (^)(id responseObject))success
+                                        failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(method);
     NSParameterAssert(filePath);
@@ -252,7 +259,7 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
             failure(fileError);
         }
 
-        return;
+        return nil;
     }
 
     destinationPath = AFPathByEscapingSpacesWithPlusSigns(destinationPath);
@@ -273,7 +280,7 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
                 failure(requestError);
             }
 
-            return;
+            return nil;
         }
     } else {
         request = [self.requestSerializer requestWithMethod:method URLString:[[self.baseURL URLByAppendingPathComponent:destinationPath] absoluteString] parameters:parameters error:nil];
@@ -293,17 +300,19 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
     [requestOperation setUploadProgressBlock:progress];
 
     [self.operationQueue addOperation:requestOperation];
+    
+    return requestOperation;
 }
 
-- (void)deleteObjectWithPath:(NSString *)path
-                     success:(void (^)(id responseObject))success
-                     failure:(void (^)(NSError *error))failure
+- (AFHTTPRequestOperation *)deleteObjectWithPath:(NSString *)path
+                                         success:(void (^)(id responseObject))success
+                                         failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(path);
 
     path = AFPathByEscapingSpacesWithPlusSigns(path);
 
-    [self enqueueS3RequestOperationWithMethod:@"DELETE" path:path parameters:nil success:success failure:failure];
+    return [self enqueueS3RequestOperationWithMethod:@"DELETE" path:path parameters:nil success:success failure:failure];
 }
 
 #pragma mark - NSKeyValueObserving


### PR DESCRIPTION
This fixes issue #72, allowing clients of the library to easily be able to cancel requests after they were submitted.