### PR TITLE
S3 expects parameters as headers for PUT requests

### DIFF
--- a/AFAmazonS3Manager/AFAmazonS3Manager.m
+++ b/AFAmazonS3Manager/AFAmazonS3Manager.m
@@ -283,7 +283,15 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
             return nil;
         }
     } else {
-        request = [self.requestSerializer requestWithMethod:method URLString:[[self.baseURL URLByAppendingPathComponent:destinationPath] absoluteString] parameters:parameters error:nil];
+        request = [self.requestSerializer requestWithMethod:method URLString:[[self.baseURL URLByAppendingPathComponent:destinationPath] absoluteString] parameters:nil error:nil];
+        
+        // S3 expects parameters as headers for PUT requests
+        if (parameters != nil) {
+            for (id key in parameters) {
+                [request setValue:[parameters objectForKey:key] forHTTPHeaderField:key];
+            }
+        }
+        
         request.HTTPBody = data;
     }
 


### PR DESCRIPTION
It currently isn't possible to set parameters (e.g. `x-amz-acl`) for PUT request uploads, since AWS expects them as headers, not form data.

This patch uses the passed parameters argument to populate headers for PUT request headers.

Note that this is a starting point, I'm not confident about general correctness, in particular in regards to interaction with `AFAWSSignatureForRequest` (which is explicitly looking for `x-amz` headers).