### PR TITLE
fixes complier warning in Xcode 6.3 beta 3

### DIFF
--- a/AFAmazonS3Manager/AFAmazonS3Manager.m
+++ b/AFAmazonS3Manager/AFAmazonS3Manager.m
@@ -35,6 +35,7 @@ static NSString * AFPathByEscapingSpacesWithPlusSigns(NSString *path) {
 
 @implementation AFAmazonS3Manager
 @synthesize baseURL = _s3_baseURL;
+@dynamic requestSerializer;
 
 - (instancetype)initWithBaseURL:(NSURL *)url {
     self = [super initWithBaseURL:url];


### PR DESCRIPTION
When using Xcode 6.3 Beta 3 AFAmazonS3Manager.h generates a compiler warning as follows: 

"Auto property synthesis will not synthesize property 'requestSerializer'; it will be implemented by its superclass, use @dynamic to acknowledge intention"

Adding @dynamic to the @implementation file seems to fix the issue
