### PR TITLE
Make safe requests to scheme://region/bucket

### DIFF
--- a/AFAmazonS3Manager/AFAmazonS3RequestSerializer.m
+++ b/AFAmazonS3Manager/AFAmazonS3RequestSerializer.m
@@ -164,7 +164,7 @@ static NSString * AFAWSSignatureForRequest(NSURLRequest *request, NSString *buck
     NSString *URLString = nil;
     NSString *scheme = self.useSSL ? @"https" : @"http";
     if (self.bucket) {
-        URLString = [NSString stringWithFormat:@"%@://%@.%@", scheme, self.bucket, self.region];
+        URLString = [NSString stringWithFormat:@"%@://%@/%@", scheme, self.region, self.bucket];
     } else {
         URLString = [NSString stringWithFormat:@"%@://%@", scheme, self.region];
     }


### PR DESCRIPTION
### What

Make safe requests to `scheme://region/bucket` rather than `scheme://bucket.region`.
### Why

Making requests to `scheme://bucket.region` only works for a subset of S3 buckets. It assumes the S3 bucket name is a valid hostname and someone may have an underscore in the name. It also causes requests to S3 buckets that have full stops in the name since the SSL certificate will not be valid for the subdomain of the bucket subdomain.
### Examples
##### Bucket name is an invalid hostname

Bucket: `test_bucket`  
`https://test_bucket.s3.amazonaws.com` => `https://s3.amazonaws.com/test_bucket`
##### Bucket name contains full stops

Bucket: test.com
`https://test.com.s3.amazonaws.com` => `https://s3.amazonaws.com/test.com`  
