### PR TITLE
Use proper #import namespacing

### DIFF
--- a/AFAmazonS3Manager/AFAmazonS3Manager.h
+++ b/AFAmazonS3Manager/AFAmazonS3Manager.h
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFHTTPRequestOperationManager.h"
+#import <AFNetworking/AFHTTPRequestOperationManager.h>
 #import "AFAmazonS3RequestSerializer.h"
 
 /**

--- a/AFAmazonS3Manager/AFAmazonS3RequestSerializer.h
+++ b/AFAmazonS3Manager/AFAmazonS3RequestSerializer.h
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFURLRequestSerialization.h"
+#import <AFNetworking/AFURLRequestSerialization.h>
 
 /**
  `AFAmazonS3RequestSerializer` is an `AFHTTPRequestSerializer` subclass with convenience methods for creating requests for the Amazon S3 webservice, including creating an authorization header and building an endpoint URL for a given bucket, region, and TLS preferences. 

--- a/AFAmazonS3Manager/AFAmazonS3ResponseSerializer.h
+++ b/AFAmazonS3Manager/AFAmazonS3ResponseSerializer.h
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFURLResponseSerialization.h"
+#import <AFNetworking/AFURLResponseSerialization.h>
 
 /**
  Returns an `AFAmazonS3ResponseObject` object from the AmazonS3 HTTP response


### PR DESCRIPTION
When using this project in a framework, it is necessary to properly
namespace imports to avoid errors about "non-modular headers".
