### PR TITLE
moved import of AFAmazonS3ResponseSerializer.h

### DIFF
--- a/AFAmazonS3Manager/AFAmazonS3Manager.m
+++ b/AFAmazonS3Manager/AFAmazonS3Manager.m
@@ -21,7 +21,6 @@
 // THE SOFTWARE.
 
 #import "AFAmazonS3Manager.h"
-#import "AFAmazonS3ResponseSerializer.h"
 
 NSString * const AFAmazonS3ManagerErrorDomain = @"com.alamofire.networking.s3.error";
 


### PR DESCRIPTION
to the .h so developers only have to import the main AFAmazonS3Manager.h file #107 #108 
